### PR TITLE
Minor fix about the capacities used in tests

### DIFF
--- a/hardhat-project/test/test_NativeDistributor/03_multipleUsers.js
+++ b/hardhat-project/test/test_NativeDistributor/03_multipleUsers.js
@@ -143,7 +143,7 @@ describe("Multiple users", function () {
         });
 
         it("1: [1, 1, 1, ... , 1]", async function () {
-          let customEpochCapacity = customEpochCapacities[3];
+          let customEpochCapacity = customEpochCapacities[4];
           let { nativeDistributor } = await deployNativeDistributor({ _epochCapacity: customEpochCapacity });
           let accounts = await ethers.getSigners();
           for (i = 1; i <= 19; i++) {

--- a/hardhat-project/test/test_PublicDistributor/03_multipleUsers.js
+++ b/hardhat-project/test/test_PublicDistributor/03_multipleUsers.js
@@ -143,7 +143,7 @@ describe("PublicDistributor multiple users", function () {
         });
 
         it("1: [1, 1, 1, ... , 1]", async function () {
-          let customEpochCapacity = customEpochCapacities[3];
+          let customEpochCapacity = customEpochCapacities[4];
           let { nativeDistributor } = await deployNativeDistributor(
             { 
               _isPermissioned: false,

--- a/hardhat-project/test/test_SMFDistributor/02_multipleUsers.js
+++ b/hardhat-project/test/test_SMFDistributor/02_multipleUsers.js
@@ -162,7 +162,7 @@ describe("SMFDistributor multiple users", function () {
         });
 
         it("1: [1, 1, 1, ... , 1]", async function () {
-          let customEpochCapacity = customEpochCapacities[3];
+          let customEpochCapacity = customEpochCapacities[4];
           let { nativeDistributor } = await deployNativeDistributor(
             {
               _isPermissioned: false,


### PR DESCRIPTION
* Before this branch, the test that applies the calculation `1: [1, 1, 1, ... , 1]` used 5 as the `epochCapacity` value (although it should have used 1 as shown in the test's name).
* This pull request includes changes in multiple test files to fix this error.