### PR TITLE
Add AvalancheJS submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "subnet/avalanchejs"]
+	path = subnet/avalanchejs
+	url = https://github.com/ava-labs/avalanchejs


### PR DESCRIPTION
This pull request adds AvalancheJS repository as a submodule into the project, under `subnet/avalanchejs`.